### PR TITLE
Inverting depth & constitutional characterization

### DIFF
--- a/pyKVFinder/main.py
+++ b/pyKVFinder/main.py
@@ -874,14 +874,6 @@ def run_workflow(
         # Spatial characterization
         surface, volume, area = spatial(cavities, step, None, nthreads, verbose)
 
-        # Depth characterization
-        if include_depth:
-            depths, max_depth, avg_depth = depth(
-                cavities, step, None, nthreads, verbose
-            )
-        else:
-            depths, max_depth, avg_depth = None, None, None
-
         # Constitutional characterization
         residues = constitutional(
             cavities,
@@ -895,6 +887,14 @@ def run_workflow(
             verbose,
         )
         frequencies = calculate_frequencies(residues)
+
+        # Depth characterization
+        if include_depth:
+            depths, max_depth, avg_depth = depth(
+                cavities, step, None, nthreads, verbose
+            )
+        else:
+            depths, max_depth, avg_depth = None, None, None
 
         # Hydropathy hydrophobicity scales
         if include_hydropathy:


### PR DESCRIPTION
Hi! :wave: 

This PR proposes a _quick_ fix to the segmentation fault issue #11.  

As pointed out in https://github.com/LBC-LNBio/pyKVFinder/issues/11,  inverting characterization order seems to prevent the memory error - which explains why the CLI version does not fail. 

This does not probably fix the root cause, but with @AJVelezRueda we arrived to the same conclusion. We are also quite sure that although the `constitutional` implementation is producing it, it may be rooted in the `depth` implementation - bypassing it prevents the segmentation fault. 

We tested this change running it multiple times - both in independent processes and within the same process   - and now we can not reproduce the segmentation fault anymore. 

Hope this helps. Thanks!
 

