### PR TITLE
Fix memory leak

### DIFF
--- a/C/pyKVFinder.c
+++ b/C/pyKVFinder.c
@@ -1981,7 +1981,7 @@ char **interface(int *cavities, int nx, int ny, int nz, char **pdb,
   char **residues;
 
   // Allocate memory for reslist structure
-  res *reslist[ncav], *new;
+  res *reslist[ncav], *new, *old;
 
   // Initialize linked list
   for (i = 0; i < ncav; i++)
@@ -2031,9 +2031,10 @@ char **interface(int *cavities, int nx, int ny, int nz, char **pdb,
     new = reslist[i];
     while (new != NULL) {
       residues[j++] = pdb[new->pos];
-      new = new->next;
+      old = new;
+      new = old->next;
+      free(old);
     }
-    free(reslist[i]);
     residues[j++] = "-1";
   }
   residues[j] = NULL;


### PR DESCRIPTION
Hi again! :see_no_evil: 

While trying to find the root cause of https://github.com/LBC-LNBio/pyKVFinder/issues/11 in https://github.com/LBC-LNBio/pyKVFinder/pull/13, I discover a memory leak near the culprit code.  

The `res` nodes' memory in `interface` was not being released, only the first node was being properly free'd, and the rest of the linked list was being left as-is. 

Here there is a `valgrind` summary **before** the change - only relevant sections have been preserved -: 

```
(...)
==214798== 7,504 (48 direct, 7,456 indirect) bytes in 3 blocks are definitely lost in loss record 496 of 521
==214798==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==214798==    by 0x9C6FEE0: create (pyKVFinder.c:1917)
==214798==    by 0x9C7072A: interface (pyKVFinder.c:2021)
==214798==    by 0x9C70C05: _constitutional (pyKVFinder.c:2100)
==214798==    by 0x9C5E740: _wrap__constitutional (pyKVFinder_wrap.c:6888)
==214798==    by 0x5F69C9: PyCFunction_Call (in /usr/bin/python3.8)
==214798==    by 0x5F74F5: _PyObject_MakeTpCall (in /usr/bin/python3.8)
==214798==    by 0x570D54: _PyEval_EvalFrameDefault (in /usr/bin/python3.8)
==214798==    by 0x569DB9: _PyEval_EvalCodeWithName (in /usr/bin/python3.8)
==214798==    by 0x5F6EB2: _PyFunction_Vectorcall (in /usr/bin/python3.8)
==214798==    by 0x56BACC: _PyEval_EvalFrameDefault (in /usr/bin/python3.8)
==214798==    by 0x569DB9: _PyEval_EvalCodeWithName (in /usr/bin/python3.8)
(...)
==214798== LEAK SUMMARY:
==214798==    definitely lost: 1,984 bytes in 4 blocks
==214798==    indirectly lost: 7,456 bytes in 466 blocks
==214798==      possibly lost: 181,191 bytes in 111 blocks
==214798==    still reachable: 1,743,596 bytes in 1,015 blocks
==214798==         suppressed: 32 bytes in 1 blocks
==214798== Reachable blocks (those to which a pointer was found) are not shown.
==214798== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==214798==
==214798== For lists of detected and suppressed errors, rerun with: -s
==214798== ERROR SUMMARY: 5468 errors from 256 contexts (suppressed: 3 from 1)
```

**After** the fix, those `7,456 indirect` bytes are no more. This is the new summary: 

```
(...)
==218836== LEAK SUMMARY:
==218836==    definitely lost: 1,936 bytes in 1 blocks
==218836==    indirectly lost: 0 bytes in 0 blocks
==218836==      possibly lost: 181,191 bytes in 111 blocks
==218836==    still reachable: 1,743,596 bytes in 1,015 blocks
==218836==         suppressed: 32 bytes in 1 blocks
==218836== Reachable blocks (those to which a pointer was found) are not shown.
==218836== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==218836==
==218836== For lists of detected and suppressed errors, rerun with: -s
==218836== ERROR SUMMARY: 5467 errors from 255 contexts (suppressed: 3 from 1)
```

Thanks for reviewing the previous PR. I promise this will be the last PR for now :pray: