### PR TITLE
Fix definition of cavity-bulk boundary limits

### DIFF
--- a/C/pyKVFinder.c
+++ b/C/pyKVFinder.c
@@ -1380,12 +1380,12 @@ void _spatial(int *cavities, int nx, int ny, int nz, int *surface, int size,
  *
  */
 typedef struct POINTS {
-  double X1;
-  double Y1;
-  double Z1;
-  double X2;
-  double Y2;
-  double Z2;
+  int X1;
+  int Y1;
+  int Z1;
+  int X2;
+  int Y2;
+  int Z2;
 } pts;
 
 /*
@@ -1456,6 +1456,7 @@ void filter_boundary(int *cavities, int nx, int ny, int nz, pts *cavs,
     for (i = 0; i < nx; i++)
       for (j = 0; j < ny; j++)
         for (k = 0; k < nz; k++)
+          #pragma omp critical
           if (cavities[k + nz * (j + (ny * i))] > 1) {
             // Get cavity identifier
             tag = cavities[k + nz * (j + (ny * i))] - 2;
@@ -1659,12 +1660,18 @@ void _depth(int *cavities, int nx, int ny, int nz, double *depths, int size,
 
   // Initialize boundaries and cavs points
   for (i = 0; i < ncav; i++) {
-    boundaries[i].X1 = cavs[i].X1 = nx;
-    boundaries[i].Y1 = cavs[i].Y1 = ny;
-    boundaries[i].Z1 = cavs[i].Z1 = nz;
-    boundaries[i].X2 = cavs[i].X2 = 0.0;
-    boundaries[i].Y2 = cavs[i].Y2 = 0.0;
-    boundaries[i].Z2 = cavs[i].Z2 = 0.0;
+    boundaries[i].X1 = nx;
+    boundaries[i].Y1 = ny;
+    boundaries[i].Z1 = nz;
+    boundaries[i].X2 = 0.0;
+    boundaries[i].Y2 = 0.0;
+    boundaries[i].Z2 = 0.0;
+    cavs[i].X1 = nx;
+    cavs[i].Y1 = ny;
+    cavs[i].Z1 = nz;
+    cavs[i].X2 = 0.0;
+    cavs[i].Y2 = 0.0;
+    cavs[i].Z2 = 0.0;
   }
 
   if (verbose)

--- a/pyKVFinder/grid.py
+++ b/pyKVFinder/grid.py
@@ -1,4 +1,3 @@
-from asyncio import open_unix_connection
 import os
 import pathlib
 import numpy

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -1,7 +1,18 @@
 import unittest
 import os
-import numpy
 import pyKVFinder
+
+
+def repeat(times):
+    def repeatHelper(f):
+        def callHelper(*args):
+            for i in range(0, times):
+                print(i, end=", ", flush=True)
+                f(*args)
+
+        return callHelper
+
+    return repeatHelper
 
 
 class TestPackage(unittest.TestCase):
@@ -129,8 +140,11 @@ class TestPackage(unittest.TestCase):
     def test_detect(self):
         self.assertEqual(self.cavities.max() - 1 > 0, True)
 
+    @repeat(100)
     def test_cavity_tags_within_bounds(self):
         # Check if cavity tags are within expeted bounds [-1, ncav+1]
+        # NOTE: A segmentation fault error has occurred in ~1/70 times.
+        # So we run the test 100 times to make sure it's not happening.
         # Detection
         ncav, cavities = pyKVFinder.detect(self.atomic, self.vertices)
         self.assertEqual(((cavities >= -1) & (cavities <= ncav + 1)).all(), True)

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -6,8 +6,7 @@ import pyKVFinder
 def repeat(times):
     def repeatHelper(f):
         def callHelper(*args):
-            for i in range(0, times):
-                print(i, end=", ", flush=True)
+            for _ in range(0, times):
                 f(*args)
 
         return callHelper

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -3,6 +3,7 @@ import os
 import numpy
 import pyKVFinder
 
+
 class TestPackage(unittest.TestCase):
     def setUp(self):
         self.vdw = os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "vdw.dat")
@@ -86,7 +87,7 @@ class TestPackage(unittest.TestCase):
 
     def test_read_cavity(self):
         grid = pyKVFinder.read_cavity(self.cavity, self.pdb)
-        self.assertEqual(grid.max()-1 > 0, True)
+        self.assertEqual(grid.max() - 1 > 0, True)
 
     def test_get_vertices(self):
         # Expected
@@ -124,46 +125,116 @@ class TestPackage(unittest.TestCase):
         )
         self.assertListEqual(vertices.tolist(), expected)
         self.assertEqual(len(atomic), 388)
-    
+
     def test_detect(self):
-        self.assertEqual(self.cavities.max()-1 > 0, True)
+        self.assertEqual(self.cavities.max() - 1 > 0, True)
+
+    def test_cavity_tags_within_bounds(self):
+        # Check if cavity tags are within expeted bounds [-1, ncav+1]
+        # Detection
+        ncav, cavities = pyKVFinder.detect(self.atomic, self.vertices)
+        self.assertEqual(((cavities >= -1) & (cavities <= ncav + 1)).all(), True)
+        # Depth characterization
+        depths, max_depth, avg_depth = pyKVFinder.depth(cavities)
+        self.assertEqual(((cavities >= -1) & (cavities <= ncav + 1)).all(), True)
+        # Constitutional characterization
+        residues = pyKVFinder.constitutional(cavities, self.atomic, self.vertices)
+        self.assertEqual(((cavities >= -1) & (cavities <= ncav + 1)).all(), True)
+        # Surface characterization
+        surface, volume, area = pyKVFinder.spatial(cavities)
+        self.assertEqual(((cavities >= -1) & (cavities <= ncav + 1)).all(), True)
+        # Hydropathy characterization
+        pyKVFinder.hydropathy(surface, self.atomic, self.vertices)
+        self.assertEqual(((cavities >= -1) & (cavities <= ncav + 1)).all(), True)
 
     def test_surface(self):
-        self.assertEqual(self.surface.max()-1 > 0, True)
+        self.assertEqual(self.surface.max() - 1 > 0, True)
 
     def test_depth(self):
         self.depths, max_depth, avg_depth = pyKVFinder.depth(self.cavities)
         self.assertEqual(self.depths.sum() > 0.0, True)
         # Apply selection
-        depths, max_depth, avg_depth = pyKVFinder.depth(self.cavities, selection=['KAA'])
-        self.assertListEqual(list(max_depth.keys()), ['KAA'])
+        depths, max_depth, avg_depth = pyKVFinder.depth(
+            self.cavities, selection=["KAA"]
+        )
+        self.assertListEqual(list(max_depth.keys()), ["KAA"])
 
     def test_constitutional(self):
         # Full constitutional (interface residues, frequencies, bar charts)
         residues = pyKVFinder.constitutional(self.cavities, self.atomic, self.vertices)
         cavity_names = list(residues.keys())
         self.assertEqual(len(cavity_names) > 0, True)
-        frequencies = pyKVFinder.calculate_frequencies(residues)        
+        frequencies = pyKVFinder.calculate_frequencies(residues)
         cavity_names = list(residues.keys())
         self.assertEqual(len(cavity_names) > 0, True)
-        pyKVFinder.plot_frequencies(frequencies, os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "barplots.pdf"))
+        pyKVFinder.plot_frequencies(
+            frequencies,
+            os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "barplots.pdf",
+            ),
+        )
         # Ignore backbone
-        interface_residues = sum([ len(r) for r in residues.values() ])
-        residues = pyKVFinder.constitutional(self.cavities, self.atomic, self.vertices, ignore_backbone=True)
-        self.assertEqual(interface_residues > sum([ len(r) for r in residues.values() ]), True)
+        interface_residues = sum([len(r) for r in residues.values()])
+        residues = pyKVFinder.constitutional(
+            self.cavities, self.atomic, self.vertices, ignore_backbone=True
+        )
+        self.assertEqual(
+            interface_residues > sum([len(r) for r in residues.values()]), True
+        )
 
     def test_hydropathy(self):
-        scales, avg_hydropathy = pyKVFinder.hydropathy(self.surface, self.atomic, self.vertices)
+        scales, avg_hydropathy = pyKVFinder.hydropathy(
+            self.surface, self.atomic, self.vertices
+        )
         cavity_names = list(avg_hydropathy.keys())
         self.assertEqual(len(cavity_names) > 0, True)
         self.assertEqual(scales.sum() != 0.0, True)
-    
+
     def test_export(self):
-        pyKVFinder.export(os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "cavities-test.pdb"),
-        self.cavities, self.surface, self.vertices)
-    
+        pyKVFinder.export(
+            os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "cavities-test.pdb",
+            ),
+            self.cavities,
+            self.surface,
+            self.vertices,
+        )
+
     def test_write_results(self):
-        pyKVFinder.write_results(os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "results.toml"), input=self.pdb, ligand=self.ligand, output=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "cavities-test.pdb"), output_hydropathy=None, volume=None, area=None, max_depth=None, avg_depth=None, avg_hydropathy=None, residues=None, frequencies=None)
+        pyKVFinder.write_results(
+            os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "results.toml",
+            ),
+            input=self.pdb,
+            ligand=self.ligand,
+            output=os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "cavities-test.pdb",
+            ),
+            output_hydropathy=None,
+            volume=None,
+            area=None,
+            max_depth=None,
+            avg_depth=None,
+            avg_hydropathy=None,
+            residues=None,
+            frequencies=None,
+        )
 
 
 class TestPackageWorkflow(unittest.TestCase):
@@ -173,44 +244,137 @@ class TestPackageWorkflow(unittest.TestCase):
             os.path.dirname(pyKVFinder.__file__), "data", "tests", "1FMO.pdb"
         )
         # Full workflow
-        self.results = pyKVFinder.run_workflow(self.pdb, include_depth=True, include_hydropathy=True, hydrophobicity_scale='EisenbergWeiss')
-    
-    def test_standard(self):
+        self.results = pyKVFinder.run_workflow(
+            self.pdb,
+            include_depth=True,
+            include_hydropathy=True,
+            hydrophobicity_scale="EisenbergWeiss",
+        )
+
+    def test_standard_workflow(self):
         results = pyKVFinder.run_workflow(self.pdb)
         self.assertEqual(results.ncav > 0, True)
-    
+
+    def test_full_workflow(self):
+        results = pyKVFinder.run_workflow(
+            self.pdb,
+            include_depth=True,
+            include_hydropathy=True,
+            hydrophobicity_scale="EisenbergWeiss",
+        )
+        self.assertEqual(results.ncav > 0, True)
+
     def test_ligand_mode(self):
-        results = pyKVFinder.run_workflow(self.pdb, os.path.join(
-            os.path.dirname(pyKVFinder.__file__), "data", "tests", "ADN.pdb"
-        ))
+        results = pyKVFinder.run_workflow(
+            self.pdb,
+            os.path.join(
+                os.path.dirname(pyKVFinder.__file__), "data", "tests", "ADN.pdb"
+            ),
+        )
         self.assertEqual(results.ncav > 0, True)
 
     def test_residues_box(self):
-        results = pyKVFinder.run_workflow(self.pdb, box=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "residues-box.toml"))
+        results = pyKVFinder.run_workflow(
+            self.pdb,
+            box=os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "residues-box.toml",
+            ),
+        )
         self.assertEqual(results.ncav > 0, True)
 
     def test_custom_box(self):
-        results = pyKVFinder.run_workflow(self.pdb, box=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "custom-box.toml"))
+        results = pyKVFinder.run_workflow(
+            self.pdb,
+            box=os.path.join(
+                os.path.dirname(pyKVFinder.__file__), "data", "tests", "custom-box.toml"
+            ),
+        )
         self.assertEqual(results.ncav, 1)
-    
+
     def test_pyKVFinderResults_methods(self):
         # export
-        self.results.export(output=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "cavities.pdb"), output_hydropathy=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "hydropathy.pdb"))
+        self.results.export(
+            output=os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "cavities.pdb",
+            ),
+            output_hydropathy=os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "hydropathy.pdb",
+            ),
+        )
         # write
         self.results.write(
-            fn=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "results.toml"), 
-            output=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "cavities.pdb"), 
-            output_hydropathy=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "hydropathy.pdb")
+            fn=os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "results.toml",
+            ),
+            output=os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "cavities.pdb",
+            ),
+            output_hydropathy=os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "hydropathy.pdb",
+            ),
         )
         # plot_frequencies
-        self.results.plot_frequencies( 
-            pdf=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "barplots.pdf")) 
+        self.results.plot_frequencies(
+            pdf=os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "barplots.pdf",
+            )
+        )
         # export_all
         self.results.export_all(
-            fn=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "results.toml"),
-            output=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "cavities.pdb"), 
-            output_hydropathy=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "hydropathy.pdb"),
+            fn=os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "results.toml",
+            ),
+            output=os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "cavities.pdb",
+            ),
+            output_hydropathy=os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "hydropathy.pdb",
+            ),
             include_frequencies_pdf=True,
-            pdf=os.path.join(os.path.dirname(pyKVFinder.__file__), "data", "tests", "output", "barplots.pdf")
-            )  
-    
+            pdf=os.path.join(
+                os.path.dirname(pyKVFinder.__file__),
+                "data",
+                "tests",
+                "output",
+                "barplots.pdf",
+            ),
+        )

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -551,11 +551,15 @@ class TestConstitutional(unittest.TestCase):
             ["13", "E", "GLU", "C", "1.0", "1.0", "1.0", "1.908"],
         ]
         # Dummy vertices
-        vertices = numpy.array([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
+        vertices = numpy.array(
+            [[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]
+        )
         # Surface
         residues = constitutional(cavities, atomic, vertices)
         # Assert
-        self.assertDictEqual(residues, {"KAA": [["13", "E", "GLU"]], "KAB": [["13", "E", "GLU"]]})
+        self.assertDictEqual(
+            residues, {"KAA": [["13", "E", "GLU"]], "KAB": [["13", "E", "GLU"]]}
+        )
 
 
 class TestConstitutional(unittest.TestCase):
@@ -578,9 +582,13 @@ class TestConstitutional(unittest.TestCase):
             ["13", "E", "GLU", "C", "1.0", "1.0", "1.0", "1.908"],
         ]
         # Dummy vertices
-        vertices = numpy.array([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
+        vertices = numpy.array(
+            [[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]
+        )
         # Surface
         scales, avg_hydropathy = hydropathy(surface, atomic, vertices)
         # Assert
         self.assertListEqual(scales.tolist(), expected.tolist())
-        self.assertDictEqual(avg_hydropathy, {'KAA': 0.38, 'KAB': 0.38, 'EisenbergWeiss': [-1.42, 2.6]})
+        self.assertDictEqual(
+            avg_hydropathy, {"KAA": 0.38, "KAB": 0.38, "EisenbergWeiss": [-1.42, 2.6]}
+        )


### PR DESCRIPTION
Based on PR #13, the cavity-bulk boundary (negative integer of the cavity tag) was not reset to its positive value after depth characterization. Investigating it, we identified that `remove_boundary` function was responsible for this unexpected behavior. So cavity tags with negative value was being passed to `constitutional` function, producing the Segmentation fault error.

Inspecting `remove_boundary`, we identified that the limits of `boundaries` (cavity-boundary limits per cavity tag) was missing some boundary points in the border. So we fixed the definition of the limits/border of the cavity-bulk boundary in `filter_boundary` function. In this way, cavity tags are being correctly reset after depth characterization, fixing the Segmentation fault error in the`constitutional` function.