### PR TITLE
build: include pipy upload and multiple python versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest,windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Build and deploy
 on:
   release:
     types: [published]
+  workflow_dispatch: 
 
 jobs:
   build_sdist:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,28 +49,28 @@ jobs:
           name: artifacts
           path: ./wheelhouse/*.whl
 
-  # pypi-publish:
-  #   name: Upload release to PyPI
-  #   runs-on: ubuntu-latest
-  #   needs: [build_sdist, build_wheels]
-  #   environment:
-  #     name: pypi
-  #     url: https://pypi.org/p/pyKVFinder
-  #   permissions:
-  #     id-token: write
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: [build_sdist, build_wheels]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyKVFinder
+    permissions:
+      id-token: write
 
-  #   steps:
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: 3.x
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
 
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: artifacts
-  #         path: ./dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+          path: ./dist
 
-  #     - name: Publish package distributions to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
         

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest,windows-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -48,28 +48,28 @@ jobs:
           name: artifacts
           path: ./wheelhouse/*.whl
 
-  pypi-publish:
-    name: Upload release to PyPI
-    runs-on: ubuntu-latest
-    needs: [build_sdist, build_wheels]
-    environment:
-      name: pypi
-      url: https://pypi.org/p/pyKVFinder
-    permissions:
-      id-token: write
+  # pypi-publish:
+  #   name: Upload release to PyPI
+  #   runs-on: ubuntu-latest
+  #   needs: [build_sdist, build_wheels]
+  #   environment:
+  #     name: pypi
+  #     url: https://pypi.org/p/pyKVFinder
+  #   permissions:
+  #     id-token: write
 
-    steps:
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
+  #   steps:
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: 3.x
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifacts
-          path: ./dist
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifacts
+  #         path: ./dist
 
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+  #     - name: Publish package distributions to PyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         password: ${{ secrets.PYPI_API_TOKEN }}
         

--- a/C/pyKVFinder.c
+++ b/C/pyKVFinder.c
@@ -2091,7 +2091,8 @@ char **interface(int *cavities, int nx, int ny, int nz, char **pdb,
   char **residues;
 
   // Allocate memory for reslist structure
-  res *reslist[ncav], *new, *old;
+  res **reslist = malloc(ncav * sizeof(res *));
+  res *new, *old;
 
   // Initialize linked list
   for (i = 0; i < ncav; i++)
@@ -2155,6 +2156,7 @@ char **interface(int *cavities, int nx, int ny, int nz, char **pdb,
     residues[j++] = "-1";
   }
   residues[j] = NULL;
+  free(reslist);
   return residues;
 }
 

--- a/pyKVFinder/__init__.py
+++ b/pyKVFinder/__init__.py
@@ -31,7 +31,7 @@ See also
 """
 
 __name__ = "pyKVFinder"
-__version__ = "0.6.9"
+__version__ = "0.6.10"
 license = "GNU GPL-3.0 License"
 
 from .utils import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,7 @@ before-build = ["brew install gcc@9"]
 archs = ["native"]
 repair-wheel-command = ""
 test-skip = "*-macosx_arm64"
+
+[tool.cibuildwheel.windows]
+archs = ["native"]
+build = ["cp311-*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,4 +99,3 @@ test-skip = "*-macosx_arm64"
 
 [tool.cibuildwheel.windows]
 archs = ["native"]
-build = ["cp311-*"]


### PR DESCRIPTION
We aim to enhance the pyKVFinder project by introducing Windows build support. This enhancement includes the following key features:

- Integration of cibuildwheel and GitHub Actions for streamlined builds.
- Automatic PyPI upload for a seamless distribution process.
- Support for multiple Python versions, specifically 3.9, 3.10, and 3.11.
- Manual trigger option added to initiate the Build and Deploy action as needed.