### PR TITLE
Add option to return PDB as a raw string in pyKVFinder.export function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ See also:
 To install the latest release on
 [PyPI](https://pypi.org/project/pyKVFinder), run:
 
-    pip install pyKVFinder
+```bash
+pip install pyKVFinder
+```
 
 Or to install the latest developmental version, run:
 
-    git clone https://github.com/LBC-LNBio/pyKVFinder.git
-    pip install pyKVFinder
+```bash
+git clone https://github.com/LBC-LNBio/pyKVFinder.git
+pip install -e pyKVFinder
+```
 
 ## Citation
 

--- a/pyKVFinder/__init__.py
+++ b/pyKVFinder/__init__.py
@@ -31,7 +31,7 @@ See also
 """
 
 __name__ = "pyKVFinder"
-__version__ = "0.6.13"
+__version__ = "0.6.14"
 license = "GNU GPL-3.0 License"
 
 from .utils import *

--- a/pyKVFinder/main.py
+++ b/pyKVFinder/main.py
@@ -447,7 +447,7 @@ class pyKVFinderResults(object):
         self,
         output: Union[str, pathlib.Path] = "cavity.pdb",
         nthreads: Optional[int] = None,
-    ) -> None:
+    ) -> Optional[str]:
         """Exports cavitiy (H) and surface (HA) points to PDB-formatted file
         with a variable (B; optional) in B-factor column, and hydropathy to
         PDB-formatted file in B-factor column at surface points (HA).
@@ -459,6 +459,11 @@ class pyKVFinderResults(object):
         nthreads : int, optional
             Number of threads, by default None. If None, the number of threads is
             `os.cpu_count() - 1`.
+
+        Returns
+        -------
+        Optional[str]
+            A raw string with the PDB-formatted file.
 
         Note
         ----
@@ -475,7 +480,7 @@ class pyKVFinderResults(object):
         >>> results = pyKVFinder.run_workflow(pdb)
         >>> results.export()
         """
-        export(
+        string = export(
             output,
             self.cavities,
             self.surface,
@@ -486,11 +491,13 @@ class pyKVFinderResults(object):
             None,
             nthreads,
         )
+        if output is None:
+            return string
 
     def write(
         self,
         fn: Union[str, pathlib.Path] = "results.toml",
-        output: Optional[Union[str, pathlib.Path]] = None
+        output: Optional[Union[str, pathlib.Path]] = None,
     ) -> None:
         """
         Writes file paths and cavity characterization to TOML-formatted file
@@ -642,12 +649,15 @@ class pyKVFinderResults(object):
         >>> results.export_all(include_frequencies_pdf=True)
         """
         # Export cavity PDB file
-        self.export(output, nthreads)
+        string = self.export(output, nthreads)
         # Write KVFinder results TOML
         self.write(fn, output)
         # Plot bar charts of frequencies
         if include_frequencies_pdf:
             self.plot_frequencies(pdf)
+        # Return PDB-formatted file as a string
+        if output is None:
+            return string
 
 
 def run_workflow(


### PR DESCRIPTION
Major changes:

- `pyKVFinder.export(fn)` now accepts `None` as the `fn` input and outputs the PDB-formatted data as a raw string.

Usage:

```python
>>> import pyKVFinder
>>> results = pyKVFinder.run_workflow(pdb)
>>> string = results.export(None)
>>> print(string)
ATOM     1  H   KAA     0       0.000   0.000   0.000  1.00  0.00
...
ATOM  1000  H   KAA     0       0.000   0.000   0.000  1.00  0.00
>>> string = results.export_all(output=None)
>>> print(string)
ATOM     1  H   KAA     0       0.000   0.000   0.000  1.00  0.00
...
ATOM  1000  H   KAA     0       0.000   0.000   0.000  1.00  0.00
```

or,

```python
>>> import pyKVFinder
>>> pdb = os.path.join(os.path.dirname(pyKVFinder.__file__), 'data', 'tests', '1FMO.pdb')
>>> atomic = pyKVFinder.read_pdb(pdb)
>>> vertices = pyKVFinder.get_vertices(atomic)
>>> ncav, cavities = pyKVFinder.detect(atomic, vertices)
>>> string = pyKVFinder.export(None, cavities, None, vertices)
>>> print(string)
ATOM     1  H   KAA     0       0.000   0.000   0.000  1.00  0.00
...
ATOM  1000  H   KAA     0       0.000   0.000   0.000  1.00  0.00
```