### PR TITLE
[ENH] Add ARM64 Linux build 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
       
       # Enable QEMU emulation for ARM
       - name: Set up QEMU
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'
+        if: matrix.os == 'ubuntu-latest'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,8 @@
 name: Build and deploy
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
   workflow_dispatch: 
 
 jobs:
@@ -105,7 +104,7 @@ jobs:
           pattern: artifacts-*
           merge-multiple: true
 
-      # - name: Publish package distributions to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,9 @@
 name: Build and deploy
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
   workflow_dispatch: 
 
 jobs:
@@ -37,10 +38,16 @@ jobs:
     strategy:
       matrix:
         # macos-13: x86_64 (intel); macos-14: arm64; macos-15: arm64
-        os: [macos-13, macos-14, macos-15, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4
+      
+      # Enable QEMU emulation for ARM
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
@@ -66,7 +73,7 @@ jobs:
           echo "CC=/usr/local/opt/llvm/bin/clang" >> $GITHUB_ENV
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.23.0
+        run: python -m pip install cibuildwheel==3.1.4
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -97,7 +104,7 @@ jobs:
           pattern: artifacts-*
           merge-multiple: true
 
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      # - name: Publish package distributions to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         # macos-13: x86_64 (intel); macos-14: arm64; macos-15: arm64
-        os: [ubuntu-latest]
+        os: [macos-13, macos-14, macos-15, ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,7 @@ jobs:
       
       # Enable QEMU emulation for ARM
       - name: Set up QEMU
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all

--- a/pyKVFinder/__init__.py
+++ b/pyKVFinder/__init__.py
@@ -31,7 +31,7 @@ See also
 """
 
 __name__ = "pyKVFinder"
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 license = "GNU GPL-3.0 License"
 
 from .utils import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ before-build = [
     "brew install libomp",
 ]
 archs = ["native"]
+test-skip = "*-macosx_x86_64"
 
 [tool.cibuildwheel.windows]
 archs = ["native"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ before-build = [
 build = ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
 
 [tool.cibuildwheel.linux]
-archs = ["native"]
+archs = ["native", "aarch64"]
 
 [tool.cibuildwheel.macos]
 before-build = [
@@ -115,7 +115,6 @@ before-build = [
     "brew install libomp",
 ]
 archs = ["native"]
-test-skip = "*-macosx_x86_64"
 
 [tool.cibuildwheel.windows]
 archs = ["native"]


### PR DESCRIPTION
This pull request updates the deployment workflow and build configuration to support building ARM (aarch64) wheels and makes improvements to the CI/CD process. The main changes include updating the GitHub Actions workflow to trigger on pushes to `master`, enabling QEMU for ARM emulation, upgrading the `cibuildwheel` version, and modifying the target architectures for Linux builds. Additionally, publishing to PyPI has been temporarily disabled.

**CI/CD workflow improvements:**

* Changed the workflow trigger from release events to pushes on the `master` branch, allowing builds to run more frequently and automatically on code changes.
* Added a step to set up QEMU emulation for ARM builds, enabling cross-platform builds within the CI environment.
* Upgraded `cibuildwheel` from version 2.23.0 to 3.1.4 to leverage new features and bugfixes.
* Commented out the step that publishes built packages to PyPI, temporarily disabling automatic publishing.

**Build configuration updates:**

* Updated `pyproject.toml` to add `aarch64` (ARM 64-bit) as a target architecture for Linux builds, enabling ARM wheel generation.