### PR TITLE
[BUG] fix for probe In smaller than step size

### DIFF
--- a/C/pyKVFinder.c
+++ b/C/pyKVFinder.c
@@ -2114,7 +2114,7 @@ char **interface(int *cavities, int nx, int ny, int nz, char **pdb,
     z = yaux * sincos[0] + zaux * sincos[1];
 
     // Create a radius (H) for space occupied by probe and atom
-    H = (probe_in + atoms[3 + (atom * 4)]) / step;
+    H = ceil((probe_in + atoms[3 + (atom * 4)]) / step);
 
     // Loop around radius from atom center
     for (i = floor(x - H); i <= ceil(x + H); i++)

--- a/pyKVFinder/__init__.py
+++ b/pyKVFinder/__init__.py
@@ -31,7 +31,7 @@ See also
 """
 
 __name__ = "pyKVFinder"
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 license = "GNU GPL-3.0 License"
 
 from .utils import *

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -1280,7 +1280,9 @@ class TestConstitutional(unittest.TestCase):
         # Constitutional
         residues = constitutional(self.cavities, self.atomic, self.vertices, step=1)
         # Assert
-        self.assertDictEqual(residues, {"KAA": [["13", "E", "GLU"]]})
+        self.assertDictEqual(
+            residues, {"KAA": [["13", "E", "GLU"]], "KAB": [["13", "E", "GLU"]]}
+        )
 
     def test_probe_in_as_integer(self):
         # Constitutional


### PR DESCRIPTION
This pull request introduces a minor version bump and a bug fix to the probe radius calculation, as well as an update to a related unit test. The main focus is to improve the accuracy of spatial calculations by ensuring the probe radius is rounded up, which also affects the expected results in the test suite.

Bug fix and calculation accuracy:

* Updated the calculation of the probe radius `H` in `C/pyKVFinder.c` to use `ceil()`, ensuring the radius is always rounded up and preventing underestimation of the occupied space.

Versioning:

* Bumped the package version from `0.8.2` to `0.8.3` in `pyKVFinder/__init__.py` to reflect the bug fix.

Testing:

* Updated the expected output in `test_step_as_integer` in `tests/unit/test_grid.py` to include the additional "KAB" residue, reflecting the corrected probe radius calculation.