### PR TITLE
Alert users to the implications of HETATM and altloc PDB records

### DIFF
--- a/pyKVFinder/utils.py
+++ b/pyKVFinder/utils.py
@@ -267,11 +267,19 @@ def read_pdb(
                     atomic.append(_process_pdb_line(line, vdw))
                 if line[:6] == "HETATM":
                     flag_hetatm = True
+                if line[16]:
+                    flag_altloc = True
 
     if flag_hetatm:
         msg = f"{fn} contains non-standard residues (HETATM)."
         msg += " If these correspond to ligands, then pyKVFinder may fail to correctly identify the cavity they are bound to."
         msg += " HETATM records can be removed with external tools such as PyMOL, pdb-tools, or biotite."
+        warnings.warn(msg)
+    if flag_altloc:
+        msg = f"{fn} likely contains altloc records."
+        msg += " These indicate, where an atomic structure contains multiple different positions for the same set of atoms."
+        msg += " They often reflect the functional, dynamic motions of the protein, that occur during catalysis, ligand-binding, or allosteric regulation."
+        msg += " As these can alter the geometry of protein cavities, altloc records should be carefully reviewed and then removed with external tools such as PyMOL, pdb-tools, or biotite."
         warnings.warn(msg)
 
     return numpy.asarray(atomic)

--- a/pyKVFinder/utils.py
+++ b/pyKVFinder/utils.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import os
 import pathlib
+import warnings
 from typing import Dict, List, Optional, Union
 
 import numpy
@@ -253,6 +254,8 @@ def read_pdb(
     keep = True if model is None else False
 
     # Read file and process atoms
+    flag_hetatm = False
+    flag_altloc = False
     with open(fn, "r") as f:
         for line in f.readlines():
             if model is not None:
@@ -262,6 +265,14 @@ def read_pdb(
             if keep:
                 if line[:4] == "ATOM" or line[:6] == "HETATM":
                     atomic.append(_process_pdb_line(line, vdw))
+                if line[:6] == "HETATM":
+                    flag_hetatm = True
+
+    if flag_hetatm:
+        msg = f"{fn} contains non-standard residues (HETATM)."
+        msg += " If these correspond to ligands, then pyKVFinder may fail to correctly identify the cavity they are bound to."
+        msg += " HETATM records can be removed with external tools such as PyMOL, pdb-tools, or biotite."
+        warnings.warn(msg)
 
     return numpy.asarray(atomic)
 

--- a/pyKVFinder/utils.py
+++ b/pyKVFinder/utils.py
@@ -265,10 +265,10 @@ def read_pdb(
             if keep:
                 if line[:4] == "ATOM" or line[:6] == "HETATM":
                     atomic.append(_process_pdb_line(line, vdw))
-                if line[:6] == "HETATM":
-                    flag_hetatm = True
-                if line[16]:
-                    flag_altloc = True
+                    if line[16] != ' ':
+                        flag_altloc = True
+                    if line[:6] == "HETATM":
+                        flag_hetatm = True
 
     if flag_hetatm:
         msg = f"{fn} contains non-standard residues (HETATM)."


### PR DESCRIPTION
This commit adds warnings to `read_pdb`, which are triggered if the PDB file contains HETATM or altloc records. 
This commit is motivated by issue #156 and issue #202.