### PR TITLE
[ENH] Add warning for ncav==0 to prevent _constitutional execution

### DIFF
--- a/pyKVFinder/grid/constitutional.py
+++ b/pyKVFinder/grid/constitutional.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy
+import warnings
 
 from .cavity import _get_cavity_label, _get_cavity_name, _select_cavities
 from .geometry import _get_sincos
@@ -104,6 +105,11 @@ def constitutional(
     residues: dict[str, list[list[str]]]
         A dictionary with a list of interface residues for each detected
         cavity.
+
+    Warnings
+    --------
+    UserWarning
+        No cavities detected. Returning an empty dictionary.
 
     Raises
     ------
@@ -261,6 +267,13 @@ def constitutional(
 
     # Get number of cavities
     ncav = int(cavities.max() - 1)
+
+    if ncav == 0:
+        warnings.warn(
+            "No cavities detected. Returning an empty dictionary.",
+            UserWarning,
+        )
+        return {}
 
     # Get sincos: sine and cossine of the grid rotation angles (sina, cosa, sinb, cosb)
     sincos = _get_sincos(vertices)


### PR DESCRIPTION
This pull request improves error handling and documentation in the `constitutional` function of the `pyKVFinder/grid/constitutional.py` module, specifically addressing the case where no cavities are detected. The most important changes are:

**Error Handling Improvements:**

* Added a check in the `constitutional` function to detect when no cavities are present (`ncav == 0`). In this case, the function now issues a `UserWarning` and returns an empty dictionary instead of proceeding further.
* Imported the `warnings` module to enable issuing warnings for this scenario.

**Documentation Updates:**

* Updated the docstring for the `constitutional` function to include a new "Warnings" section, describing the warning that is raised when no cavities are detected.