### PR TITLE
[MNT] Fix/swig python3 compatibility

### DIFF
--- a/C/numpy.i
+++ b/C/numpy.i
@@ -40,6 +40,7 @@
 #define NO_IMPORT_ARRAY
 #endif
 #include "stdio.h"
+#include <string.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 %}
@@ -457,11 +458,11 @@ void free_cap(PyObject * cap)
     {
       for (i = 0; i < n-1; i++)
       {
-        sprintf(s, "%d, ", exact_dimensions[i]);
-        strcat(dims_str,s);
+        snprintf(s, sizeof(s), "%d, ", exact_dimensions[i]);
+        strncat(dims_str, s, sizeof(dims_str) - strlen(dims_str) - 1);
       }
-      sprintf(s, " or %d", exact_dimensions[n-1]);
-      strcat(dims_str,s);
+      snprintf(s, sizeof(s), " or %d", exact_dimensions[n-1]);
+      strncat(dims_str, s, sizeof(dims_str) - strlen(dims_str) - 1);
       PyErr_Format(PyExc_TypeError,
                    "Array must have %s dimensions.  Given array has %d dimensions",
                    dims_str,
@@ -497,20 +498,20 @@ void free_cap(PyObject * cap)
       {
         if (size[i] == -1)
         {
-          sprintf(s, "*,");
+          snprintf(s, sizeof(s), "*,");
         }
         else
         {
-          sprintf(s, "%ld,", (long int)size[i]);
+          snprintf(s, sizeof(s), "%ld,", (long int)size[i]);
         }
-        strcat(desired_dims,s);
+        strncat(desired_dims, s, sizeof(desired_dims) - strlen(desired_dims) - 1);
       }
       len = strlen(desired_dims);
       desired_dims[len-1] = ']';
       for (i = 0; i < n; i++)
       {
-        sprintf(s, "%ld,", (long int)array_size(ary,i));
-        strcat(actual_dims,s);
+        snprintf(s, sizeof(s), "%ld,", (long int)array_size(ary,i));
+        strncat(actual_dims, s, sizeof(actual_dims) - strlen(actual_dims) - 1);
       }
       len = strlen(actual_dims);
       actual_dims[len-1] = ']';

--- a/C/pyKVFinder.i
+++ b/C/pyKVFinder.i
@@ -136,7 +136,7 @@ char **
             break;
 
         /* Convert C string to Python string */
-        tmp = PyString_FromString( $1[nPy] );
+        tmp = PyUnicode_FromString( $1[nPy] );
         if (!tmp) 
             return NULL;
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest>=9.0.0,<9.2.0",
     "pytest-cov>=7.0.0,<7.2.0",
@@ -87,6 +87,9 @@ issues = "https://github.com/LBC-LNBio/pyKVFinder/issues"
 
 [project.scripts]
 pyKVFinder = "pyKVFinder.main:cli"
+
+[tool.uv.dependency-groups]
+docs = {requires-python = ">=3.12"}
 
 [tool.setuptools]
 packages = ["pyKVFinder", "pyKVFinder.grid", "pyKVFinder.data", "pyKVFinder.data.tests"]


### PR DESCRIPTION
This pull request focuses on improving C code safety, updating Python compatibility, and modernizing dependency management. The most important changes are grouped below:

### C code safety improvements

* Replaced unsafe `sprintf`/`strcat` calls with safer `snprintf`/`strncat` in `numpy.i` to prevent buffer overflows when constructing dimension strings. Also included `<string.h>` to support these functions. [[1]](diffhunk://#diff-11e3cd22d17e51cfdc49d065390c9f7c0ba3bf712d21ec8c8e663f554d9d7f5bR43) [[2]](diffhunk://#diff-11e3cd22d17e51cfdc49d065390c9f7c0ba3bf712d21ec8c8e663f554d9d7f5bL460-R465) [[3]](diffhunk://#diff-11e3cd22d17e51cfdc49d065390c9f7c0ba3bf712d21ec8c8e663f554d9d7f5bL500-R514)

### Python compatibility updates

* Updated string conversion in `pyKVFinder.i` from `PyString_FromString` to `PyUnicode_FromString` to ensure compatibility with Python 3.

### Dependency management modernization

* Switched from `[project.optional-dependencies]` to `[dependency-groups]` in `pyproject.toml` for a more modern and flexible dependency grouping.
* Added a `[tool.uv.dependency-groups]` section for documentation dependencies, specifying Python 3.12+ is required.