### PR TITLE
[MNT] Migrate workflows from master branch to main branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,9 @@ jobs:
           python -m pip install --upgrade pip
 
       - name: Build pyKVFinder
-        run: pip install -e .[dev]
+        run: |
+          pip install -e .
+          pip install "pytest>=9.0.0,<9.2.0" "pytest-cov>=7.0.0,<7.2.0"
 
       - name: Run test coverage
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: Pytest Coverage
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   coverage:
@@ -38,7 +38,7 @@ jobs:
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-coverage-path: coverage.txt
-          default-branch: master
+          default-branch: main
           remove-link-from-badge: true
 
       - name: Move report to coverage directory

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [created]
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -2,9 +2,9 @@ name: Unit Testing
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   testing:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration files to switch the default branch reference from `master` to `main`. This ensures that all CI/CD workflows now correctly target the `main` branch, reflecting the repository's updated branch naming conventions.

**CI/CD workflow updates:**

* [`.github/workflows/coverage.yml`](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6L5-R5): Changed all references from `master` to `main` for both the branch filter in the `push` trigger and the `default-branch` input for the coverage reporting action. [[1]](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6L5-R5) [[2]](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6L41-R41)
* [`.github/workflows/integration-testing.yml`](diffhunk://#diff-3a1fea4e5bb8f47ffb16d851debf4b504b20e782df9dc03336b120d14126147dL7-R7): Updated the branch filter for the `pull_request` trigger from `master` to `main`.
* [`.github/workflows/unit-testing.yml`](diffhunk://#diff-362f6bdc8588ade30c0052b396df7bc0c3c254686c1071177915696341722589L5-R7): Updated the branch filters for both `push` and `pull_request` triggers from `master` to `main`.