### PR TITLE
[DOC] Update hydropathy information in CLI

### DIFF
--- a/pyKVFinder/argparser.py
+++ b/pyKVFinder/argparser.py
@@ -319,8 +319,9 @@ residues. (default: %(default)s)",
         action="store_true",
         default=False,
         help="Depth characterization of the detected cavities. \
-Map depth in B-factor in the cavity PDB file and maximum and average depth of \
-the detected cavities. (default: %(default)s)",
+Map depth in B-factor (temperature factor) in the cavity PDB file \
+and maximum and average depth of the detected cavities. (default: \
+%(default)s)",
     )
     extra_modes.add_argument(
         "--plot_frequencies",
@@ -338,10 +339,10 @@ RadzickaWolfenden, WimleyWhite, ZhaoLondon, <.toml>}",
         const="EisenbergWeiss",
         default=False,
         help="Hydropathy characterization of the detected cavities. Map \
-hydrophobicity scale values as B-factor at surface points of detected \
-cavities. Hydrophobicity scales options: %(metavar)s. A custom hydrophobicity \
-scale can be defined via a TOML-formatted file. (default: %(default)s) \
-(constant: %(const)s)",
+hydrophobicity scale values as Q-factor (occupancy) at surface points of \
+detected cavities. Hydrophobicity scales options: %(metavar)s. A custom \
+hydrophobicity scale can be defined via a TOML-formatted file. (default: \
+%(default)s) (constant: %(const)s)",
     )
 
     # Create argument group


### PR DESCRIPTION
This pull request updates the help messages for command-line arguments in the `pyKVFinder/argparser.py` file to clarify the terminology and improve user understanding.

**Documentation improvements:**

* Updated the help text for the depth characterization option to clarify that "B-factor" refers to "temperature factor" in the cavity PDB file.
* Updated the help text for the hydropathy characterization option to specify that hydrophobicity scale values are now mapped as "Q-factor (occupancy)" instead of "B-factor" at surface points.